### PR TITLE
Add public readonly properties to view suspension status.

### DIFF
--- a/src/DynamicData/Binding/ObservableCollectionExtended.cs
+++ b/src/DynamicData/Binding/ObservableCollectionExtended.cs
@@ -20,6 +20,10 @@ namespace DynamicData.Binding
         private bool _suspendCount;
 
         private bool _suspendNotifications;
+        
+        public bool IsNotificationsSuspended => _suspendNotifications;
+        
+        public bool IsCountSuspended => _suspendCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableCollectionExtended{T}"/> class.


### PR DESCRIPTION
It is possible to call SuspendNotifications or SuspendCount more than once and get multiple disposables that when disposed of will each reset the internal properties. By adding a public way to ask if the notification is suspended you can avoid multiple calls to suspend notifications.